### PR TITLE
handle LTV shortfall in flashloan logic + sushi router support

### DIFF
--- a/contracts/FlashLoanLib.sol
+++ b/contracts/FlashLoanLib.sol
@@ -36,8 +36,7 @@ library FlashLoanLib {
     ILendingPool private constant lendingPool =
         ILendingPool(0x7d2768dE32b0b80b7a3454c06BdAc94A69DDc7A9);
 
-    // Aave's referral code
-    uint16 private constant referral = 0;
+    uint16 private constant referral = 7; // Yearn's aave referral code
 
     function doDyDxFlashLoan(
         bool deficit,
@@ -124,7 +123,7 @@ library FlashLoanLib {
             lp.repay(want, amount, 2, address(this));
         } else {
             // 2b. if levering up borrow and deposit
-            lp.borrow(want, amount, 2, 0, address(this));
+            lp.borrow(want, amount, 2, referral, address(this));
             lp.deposit(
                 want,
                 IERC20(want).balanceOf(address(this)),

--- a/contracts/FlashLoanLib.sol
+++ b/contracts/FlashLoanLib.sol
@@ -21,6 +21,8 @@ library FlashLoanLib {
     event Leverage(
         uint256 amountRequested,
         uint256 amountGiven,
+        uint256 ethUsed,
+        uint256 amountToCloseLTVGap,
         bool deficit,
         address flashLoan
     );
@@ -101,7 +103,14 @@ library FlashLoanLib {
 
         solo.operate(accountInfos, operations);
 
-        emit Leverage(amount, requiredETH, deficit, address(solo));
+        emit Leverage(
+            amountDesired,
+            amount,
+            requiredETH,
+            depositToCloseLTVGap,
+            deficit,
+            address(solo)
+        );
 
         return amount; // we need to return the amount of Token we have changed our position in
     }

--- a/contracts/Strategy.sol
+++ b/contracts/Strategy.sol
@@ -217,6 +217,11 @@ contract Strategy is BaseStrategyInitializable, ICallee {
         uint24 _aaveToWethSwapFee,
         uint24 _wethToWantSwapFee
     ) external onlyVaultManagers {
+        require(
+            _swapRouter == SwapRouter.UniV2 ||
+                _swapRouter == SwapRouter.SushiV2 ||
+                _swapRouter == SwapRouter.UniV3
+        );
         require(_maxStkAavePriceImpactBps <= MAX_BPS);
         swapRouter = _swapRouter;
         sellStkAave = _sellStkAave;

--- a/contracts/Strategy.sol
+++ b/contracts/Strategy.sol
@@ -92,7 +92,7 @@ contract Strategy is BaseStrategyInitializable, ICallee {
 
     bool private alreadyAdjusted = false; // Signal whether a position adjust was done in prepareReturn
 
-    uint16 private constant referral = 0; // Aave's referral code
+    uint16 private constant referral = 7; // Yearn's aave referral code
 
     uint256 private constant MAX_BPS = 1e4;
     uint256 private constant BPS_WAD_RATIO = 1e14;

--- a/contracts/Strategy.sol
+++ b/contracts/Strategy.sol
@@ -55,6 +55,12 @@ contract Strategy is BaseStrategyInitializable, ICallee {
     IAToken public aToken;
     IVariableDebtToken public debtToken;
 
+    // represents stkAave cooldown status
+    // 0 = no cooldown or past withdraw period
+    // 1 = claim period
+    // 2 = cooldown initiated, future claim period
+    enum CooldownStatus {None, Claim, Initiated}
+
     // SWAP routers
     IUni private constant UNI_V2_ROUTER =
         IUni(0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D);
@@ -781,12 +787,6 @@ contract Strategy is BaseStrategyInitializable, ICallee {
     {
         return tokenToWant(weth, _amtInWei);
     }
-
-    // returns cooldown status
-    // 0 = no cooldown or past withdraw period
-    // 1 = claim period
-    // 2 = cooldown initiated, future claim period
-    enum CooldownStatus {None, Claim, Initiated}
 
     function _checkCooldown() internal view returns (CooldownStatus) {
         uint256 cooldownStartTimestamp =

--- a/contracts/Strategy.sol
+++ b/contracts/Strategy.sol
@@ -553,17 +553,17 @@ contract Strategy is BaseStrategyInitializable, ICallee {
 
     function _leverUpFlashLoan(uint256 amount) internal returns (uint256) {
         (uint256 deposits, uint256 borrows) = getCurrentPosition();
-        uint256 depositToMeetLtv =
+        uint256 depositsToMeetLtv =
             getDepositFromBorrow(borrows, maxBorrowCollatRatio);
-        uint256 depositDeficitToMeetLtv = 0;
-        if (depositToMeetLtv > deposits) {
-            depositDeficitToMeetLtv = depositToMeetLtv.sub(deposits);
+        uint256 depositsDeficitToMeetLtv = 0;
+        if (depositsToMeetLtv > deposits) {
+            depositsDeficitToMeetLtv = depositsToMeetLtv.sub(deposits);
         }
         return
             FlashLoanLib.doDyDxFlashLoan(
                 false,
                 amount,
-                depositDeficitToMeetLtv,
+                depositsDeficitToMeetLtv,
                 address(want)
             );
     }

--- a/package.json
+++ b/package.json
@@ -3,15 +3,11 @@
   "devDependencies": {
     "@commitlint/cli": "^11.0.0",
     "@commitlint/config-conventional": "^11.0.0",
-    "@yearn/yearn-vaults": "github:yearn/yearn-vaults#v0.4.3",
-    "@openzeppelin/openzeppelin": "github:OpenZeppelin/openzeppelin-contracts#v3.1.0",
     "ethlint": "^1.2.5",
-    "hardhat": "^2.6.1",
     "husky": "^4.3.0",
     "prettier": "^2.1.2",
     "prettier-plugin-solidity": "^1.0.0-alpha.57",
-    "pretty-quick": "^3.0.2",
-    "yearn-protocol": "https://github.com/yearn/yearn-vaults.git"
+    "pretty-quick": "^3.0.2"
   },
   "scripts": {
     "lint": "pretty-quick --pattern '**/*.*(sol|json)' --verbose",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "devDependencies": {
     "@commitlint/cli": "^11.0.0",
     "@commitlint/config-conventional": "^11.0.0",
+    "@yearn/yearn-vaults": "github:yearn/yearn-vaults#v0.4.3",
+    "@openzeppelin/openzeppelin": "github:OpenZeppelin/openzeppelin-contracts#v3.1.0",
     "ethlint": "^1.2.5",
     "hardhat": "^2.6.1",
     "husky": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -4,10 +4,12 @@
     "@commitlint/cli": "^11.0.0",
     "@commitlint/config-conventional": "^11.0.0",
     "ethlint": "^1.2.5",
+    "hardhat": "^2.6.1",
     "husky": "^4.3.0",
     "prettier": "^2.1.2",
     "prettier-plugin-solidity": "^1.0.0-alpha.57",
-    "pretty-quick": "^3.0.2"
+    "pretty-quick": "^3.0.2",
+    "yearn-protocol": "https://github.com/yearn/yearn-vaults.git"
   },
   "scripts": {
     "lint": "pretty-quick --pattern '**/*.*(sol|json)' --verbose",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,7 +71,7 @@ token_addresses = {
         # "WETH",  # WETH
         # 'LINK', # LINK
         # 'USDT', # USDT
-        "DAI", # DAI
+        "DAI",  # DAI
         "USDC",  # USDC
     ],
     scope="session",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,42 +8,42 @@ def shared_setup(fn_isolation):
     pass
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def gov(accounts):
     yield accounts.at("0xFEB4acf3df3cDEA7399794D0869ef76A6EfAff52", force=True)
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def strat_ms(accounts):
     yield accounts.at("0x16388463d60FFE0661Cf7F1f31a7D658aC790ff7", force=True)
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def user(accounts):
     yield accounts[0]
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def rewards(accounts):
     yield accounts[1]
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def guardian(accounts):
     yield accounts[2]
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def management(accounts):
     yield accounts[3]
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def strategist(accounts):
     yield accounts[4]
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def keeper(accounts):
     yield accounts[5]
 
@@ -71,8 +71,8 @@ token_addresses = {
         # "WETH",  # WETH
         # 'LINK', # LINK
         # 'USDT', # USDT
-        # "DAI", # DAI
-        # "USDC",  # USDC
+        "DAI", # DAI
+        "USDC",  # USDC
     ],
     scope="session",
     autouse=True,
@@ -111,8 +111,8 @@ token_prices = {
 @pytest.fixture(autouse=True)
 def amount(token, token_whale, user):
     # this will get the number of tokens (around $1m worth of token)
-    amillion = round(1_000_000 / token_prices[token.symbol()])
-    amount = amillion * 10 ** token.decimals()
+    base_amount = round(1_000_000 / token_prices[token.symbol()])
+    amount = base_amount * 10 ** token.decimals()
     # In order to get some funds for the token you are about to use,
     # it impersonate a whale address
     if amount > token.balanceOf(token_whale):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,7 +72,7 @@ token_addresses = {
         # 'LINK', # LINK
         # 'USDT', # USDT
         "DAI",  # DAI
-        "USDC",  # USDC
+        # "USDC",  # USDC
     ],
     scope="session",
     autouse=True,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -99,16 +99,16 @@ def token_whale(token):
 
 token_prices = {
     "WBTC": 45_000,
-    "WETH": 3_500,
+    "WETH": 3_000,
     "LINK": 20,
-    "YFI": 30_000,
+    "YFI": 50_000,
     "USDT": 1,
     "USDC": 1,
     "DAI": 1,
 }
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(autouse=True, scope="function")
 def amount(token, token_whale, user):
     # this will get the number of tokens (around $1m worth of token)
     base_amount = round(1_000_000 / token_prices[token.symbol()])
@@ -121,7 +121,7 @@ def amount(token, token_whale, user):
     yield amount
 
 
-@pytest.fixture()
+@pytest.fixture(scope="function")
 def big_amount(token, token_whale, user):
     # this will get the number of tokens (around $49m worth of token)
     fifty_minus_one_million = round(49_000_000 / token_prices[token.symbol()])

--- a/tests/test_deleverage.py
+++ b/tests/test_deleverage.py
@@ -131,7 +131,7 @@ def test_large_manual_deleverage_to_zero(
     assert strategy.getCurrentSupply() <= strategy.minWant()
 
     if strategy.estimatedRewardsInWant() >= strategy.minRewardToSell():
-        strategy.manualClaimAndSellRewards()
+        strategy.manualClaimAndSellRewards({"from": gov})
 
     utils.sleep()
     utils.strategy_status(vault, strategy)

--- a/tests/test_deleverage.py
+++ b/tests/test_deleverage.py
@@ -12,14 +12,14 @@ def test_large_deleverage_to_zero(
     utils.sleep(1)
     strategy.harvest({"from": strategist})
 
-    utils.strategy_status(vault, strategy)
-
     assert (
         pytest.approx(strategy.estimatedTotalAssets(), rel=RELATIVE_APPROX)
         == big_amount
     )
 
     utils.sleep(7 * 24 * 3600)
+
+    utils.strategy_status(vault, strategy)
 
     vault.revokeStrategy(strategy.address, {"from": gov})
     n = 0
@@ -51,8 +51,6 @@ def test_large_deleverage_parameter_change(
     utils.sleep(1)
     strategy.harvest({"from": strategist})
 
-    utils.strategy_status(vault, strategy)
-
     assert (
         pytest.approx(strategy.estimatedTotalAssets(), rel=RELATIVE_APPROX)
         == big_amount
@@ -66,6 +64,8 @@ def test_large_deleverage_parameter_change(
         strategy.maxBorrowCollatRatio(),
         {"from": gov},
     )
+
+    utils.strategy_status(vault, strategy)
 
     n = 0
     while (
@@ -99,12 +99,14 @@ def test_large_manual_deleverage_to_zero(
     utils.sleep(1)
     strategy.harvest({"from": strategist})
 
-    utils.strategy_status(vault, strategy)
-
     assert (
         pytest.approx(strategy.estimatedTotalAssets(), rel=RELATIVE_APPROX)
         == big_amount
     )
+
+    chain.sleep(7 * 24 * 3600)
+
+    utils.strategy_status(vault, strategy)
 
     n = 0
     while strategy.getCurrentSupply() > strategy.minWant():
@@ -125,9 +127,10 @@ def test_large_manual_deleverage_to_zero(
     print(f"manualDeleverage calls: {n} iterations")
 
     utils.sleep(1)
-    strategy.manualReleaseWant(
-        strategy.getCurrentPosition().dict()["deposits"], {"from": gov}
-    )
+    deposits = strategy.getCurrentPosition().dict()["deposits"]
+    while deposits > strategy.minWant():
+        strategy.manualReleaseWant(deposits, {"from": gov})
+        deposits = strategy.getCurrentPosition().dict()["deposits"]
     assert strategy.getCurrentSupply() <= strategy.minWant()
 
     if strategy.estimatedRewardsInWant() >= strategy.minRewardToSell():
@@ -138,7 +141,7 @@ def test_large_manual_deleverage_to_zero(
     assert (
         pytest.approx(strategy.estimatedTotalAssets(), rel=RELATIVE_APPROX)
         == big_amount
-    )
+    ) or strategy.estimatedTotalAssets() > big_amount
 
     vault.revokeStrategy(strategy.address, {"from": gov})
     strategy.harvest({"from": strategist})

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -159,7 +159,7 @@ def test_emergency_exit(
 
 
 @pytest.mark.parametrize(
-    "starting_debt_ratio", [100, 500, 1_000, 2_500, 5_000, 7_500, 9_500]
+    "starting_debt_ratio", [100, 500, 1_000, 2_500, 5_000, 7_500, 9_500, 9_900]
 )
 def test_increase_debt_ratio(
     chain,
@@ -197,7 +197,7 @@ def test_increase_debt_ratio(
 
 
 @pytest.mark.parametrize(
-    "ending_debt_ratio", [100, 500, 1_000, 2_500, 5_000, 7_500, 9_500]
+    "ending_debt_ratio", [100, 500, 1_000, 2_500, 5_000, 7_500, 9_500, 9_900]
 )
 def test_decrease_debt_ratio(
     chain,

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -136,9 +136,20 @@ def test_emergency_exit(
     assert strategy.estimatedTotalAssets() < amount
 
 
-@pytest.mark.parametrize('starting_debt_ratio', [100, 500, 1_000, 2_500, 5_000, 7_500, 9_500])
+@pytest.mark.parametrize(
+    "starting_debt_ratio", [100, 500, 1_000, 2_500, 5_000, 7_500, 9_500]
+)
 def test_increase_debt_ratio(
-    chain, gov, token, vault, strategy, user, strategist, amount, starting_debt_ratio, RELATIVE_APPROX
+    chain,
+    gov,
+    token,
+    vault,
+    strategy,
+    user,
+    strategist,
+    amount,
+    starting_debt_ratio,
+    RELATIVE_APPROX,
 ):
     # Deposit to the vault and harvest
     actions.user_deposit(user, vault, token, amount)
@@ -149,7 +160,10 @@ def test_increase_debt_ratio(
 
     utils.strategy_status(vault, strategy)
 
-    assert pytest.approx(strategy.estimatedTotalAssets(), rel=RELATIVE_APPROX) == part_amount
+    assert (
+        pytest.approx(strategy.estimatedTotalAssets(), rel=RELATIVE_APPROX)
+        == part_amount
+    )
 
     vault.updateStrategyDebtRatio(strategy.address, 10_000, {"from": gov})
     chain.sleep(1)
@@ -160,9 +174,20 @@ def test_increase_debt_ratio(
     assert pytest.approx(strategy.estimatedTotalAssets(), rel=RELATIVE_APPROX) == amount
 
 
-@pytest.mark.parametrize('ending_debt_ratio', [100, 500, 1_000, 2_500, 5_000, 7_500, 9_500])
+@pytest.mark.parametrize(
+    "ending_debt_ratio", [100, 500, 1_000, 2_500, 5_000, 7_500, 9_500]
+)
 def test_decrease_debt_ratio(
-    chain, gov, token, vault, strategy, user, strategist, amount, ending_debt_ratio, RELATIVE_APPROX
+    chain,
+    gov,
+    token,
+    vault,
+    strategy,
+    user,
+    strategist,
+    amount,
+    ending_debt_ratio,
+    RELATIVE_APPROX,
 ):
     # Deposit to the vault and harvest
     actions.user_deposit(user, vault, token, amount)
@@ -182,7 +207,10 @@ def test_decrease_debt_ratio(
     utils.strategy_status(vault, strategy)
 
     part_amount = int(amount * ending_debt_ratio / 10_000)
-    assert pytest.approx(strategy.estimatedTotalAssets(), rel=RELATIVE_APPROX) == part_amount
+    assert (
+        pytest.approx(strategy.estimatedTotalAssets(), rel=RELATIVE_APPROX)
+        == part_amount
+    )
 
 
 def test_large_deleverage(

--- a/tests/utils/utils.py
+++ b/tests/utils/utils.py
@@ -22,6 +22,9 @@ def strategy_status(vault, strategy):
     print(f"Total Loss {to_units(vault, status['totalLoss'])}")
     print(f"Estimated Total Assets {to_units(vault, strategy.estimatedTotalAssets())}")
     print(
+        f"Estimated Total Rewards {to_units(vault, strategy.estimatedRewardsInWant())}"
+    )
+    print(
         f"Loose Want {to_units(vault, Contract(strategy.want()).balanceOf(strategy))}"
     )
     print(f"Current Lend {to_units(vault, lend)}")


### PR DESCRIPTION
- fix: handle LTV shortfall in flashloan logic
- chore: cleanup
- chore: revert package.json
- chore: revert package.json
- chore: don't test usdc
